### PR TITLE
Remove githubpages extention

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
I got a `No module named githubpages` when I tried to create the document
```{shell}
$ make html
mkdir -p build
cp -rf ../src build/chimera_embedding
PYTHONPATH=build python literate.py ../examples/embed_clique.py > source/embed_clique.rst
python literate.py ../examples/solve_clique.py > source/solve_clique.rst
PYTHONPATH=build python literate.py ../examples/embed_biclique.py > source/embed_biclique.rst
python literate.py ../examples/solve_biclique.py > source/solve_biclique.rst
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v1.3.5
making output directory...

Extension error:
Could not import extension sphinx.ext.githubpages (exception: No module named githubpages)
make: *** [html] Error 1
```

This error can be fixed by removing gh-page setting in `config.py`
- https://github.com/rtfd/readthedocs.org/issues/2402
- https://github.com/rtfd/readthedocs.org/issues/2269

I know that I'm using little bit older version Sphinx included in `anaconda2-4.0.0`.
But I hope that it will be installed directly to this environment because Anacaonda is a de facto standard environment for scientific computation.